### PR TITLE
Change network mode to bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   install".
 - (Windows) Fixed kernelspecs using `/usr/bin/env python` instead of just
   `python`.
+- Changed network mode to bridge and explicitly mapped the ports. 
 
 ## [1.0.0] - 2020-07-09
 ### Added


### PR DESCRIPTION
* Changed network mode to bridge, which seems like a good idea anyway
* But mostly because this seems to be the way to go get it to work on Windows
* Bridge mode requires the ports to be mapped explicitly, which is done by reading them from the connection file and adding to docker run command
* Tested on Windows 10 and Ubuntu 20.04

Together with some the updated CMD in docker this fixes #7.